### PR TITLE
Test JDK 25-only test configuration

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "Build changed matrix"
         id: changed-matrix
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "Run Spotless"
         run: ./gradlew spotlessCheck --console=plain
@@ -82,7 +82,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "Verify repo-local Markdown links"
         run: ./gradlew checkDocLinks --console=plain
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "Run Checkstyle"
         run: ./gradlew checkstyle -Pcoordinates=${{ matrix.coordinates }} --console=plain

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix
@@ -106,7 +106,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "Get tags"
         run: |

--- a/.github/workflows/create-snapshot-release.yml
+++ b/.github/workflows/create-snapshot-release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "🔎 Determine diff base"
         id: get-base-ref
@@ -88,7 +88,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "⬆️ Update version"
         run: |

--- a/.github/workflows/index-file-validation.yml
+++ b/.github/workflows/index-file-validation.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "📋 Get changed index files"
         id: get-coords

--- a/.github/workflows/library-stats-validation.yml
+++ b/.github/workflows/library-stats-validation.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "Validate library stats"
         if: steps.filter.outputs.changed == 'true'

--- a/.github/workflows/publish-scheduled-coverage.yml
+++ b/.github/workflows/publish-scheduled-coverage.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "🌿 Prepare coverage branch workspace"
         run: |

--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -34,7 +34,7 @@ jobs:
         if: github.event_name == 'schedule' || steps.filter.outputs.changed == 'true'
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install required tools"

--- a/.github/workflows/test-affected-spring-aot-main.yml
+++ b/.github/workflows/test-affected-spring-aot-main.yml
@@ -78,12 +78,6 @@ jobs:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: "🔧 Setup Java for spring harness"
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
-        with:
-          distribution: 'graalvm'
-          java-version: ${{ matrix.java }}
-
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools
 
@@ -92,7 +86,7 @@ jobs:
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
-          set-java-home: 'false'
+          set-java-home: 'true'
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-affected-spring-aot-main.yml
+++ b/.github/workflows/test-affected-spring-aot-main.yml
@@ -37,12 +37,12 @@ jobs:
           file-patterns: |
             - 'metadata/**'
 
-      - name: "🔧 Setup Java (GraalVM 21 for harness)"
+      - name: "🔧 Setup Java (GraalVM 25 for harness)"
         if: steps.filter.outputs.changed == 'true'
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "☁️ Checkout spring-aot-smoke-tests (4.1.x)"
         if: steps.filter.outputs.changed == 'true'
@@ -66,7 +66,7 @@ jobs:
 
   test-affected-spring-aot:
     name: "🧪 ${{ matrix.project }} @ spring-aot:4.1.x (GraalVM JDK ${{ matrix.java }})"
-    if: needs.discover-impacted-tests.outputs.relevant-files-changed == 'true' && needs.discover-impacted-tests.result == 'success' && needs.discover-impacted-tests.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
+    if: needs.discover-impacted-tests.outputs.relevant-files-changed == 'true' && needs.discover-impacted-tests.result == 'success' && needs.discover-impacted-tests.outputs.none-found != 'true' && github.repository == 'jormundur00/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 480
     needs: discover-impacted-tests
@@ -82,7 +82,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '17.0.12'
+          java-version: ${{ matrix.java }}
 
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools

--- a/.github/workflows/test-affected-spring-aot-main.yml
+++ b/.github/workflows/test-affected-spring-aot-main.yml
@@ -78,6 +78,12 @@ jobs:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: "🔧 Setup Java for spring harness"
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'graalvm'
+          java-version: '17.0.12'
+
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools
 
@@ -86,7 +92,7 @@ jobs:
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
-          set-java-home: 'true'
+          set-java-home: 'false'
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-affected-spring-aot-main.yml
+++ b/.github/workflows/test-affected-spring-aot-main.yml
@@ -4,9 +4,7 @@
 name: "Test affected Spring AOT smoke tests (4.1.x)"
 
 on:
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   get-all-metadata:
-    if: github.repository == 'oracle/graalvm-reachability-metadata'
+    if: github.repository == 'jormundur00/graalvm-reachability-metadata'
     name: "📋 Get list of all supported libraries"
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "🕸️ Populate matrix"
         id: set-matrix
@@ -40,7 +40,7 @@ jobs:
 
   test-all-metadata:
     name: "🧪 ${{ matrix.coordinates }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
-    if: github.repository == 'oracle/graalvm-reachability-metadata'
+    if: github.repository == 'jormundur00/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 480
     needs: get-all-metadata
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: ${{ matrix.version }}
 
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
@@ -250,7 +250,7 @@ jobs:
     needs:
       - get-all-metadata
       - test-all-metadata
-    if: always() && github.repository == 'oracle/graalvm-reachability-metadata' && needs.get-all-metadata.result == 'success'
+    if: always() && github.repository == 'jormundur00/graalvm-reachability-metadata' && needs.get-all-metadata.result == 'success'
     outputs:
       has-failures: ${{ steps.aggregate.outputs.has-failures }}
     steps:
@@ -324,7 +324,7 @@ jobs:
     needs:
       - test-all-metadata
       - process-results
-    if: always() && github.repository == 'oracle/graalvm-reachability-metadata'
+    if: always() && github.repository == 'jormundur00/graalvm-reachability-metadata'
     steps:
       - name: "All tests passed"
         if: needs.test-all-metadata.result == 'success' && needs.process-results.result == 'success' && needs.process-results.outputs.has-failures != 'true'

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -61,18 +61,12 @@ jobs:
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools
 
-      - name: "🔧 Setup java"
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
-        with:
-          distribution: 'graalvm'
-          java-version: ${{ matrix.version }}
-
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.version }}
-          set-java-home: 'false'
+          set-java-home: 'true'
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-changed-infrastructure.yml
+++ b/.github/workflows/test-changed-infrastructure.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "🕸️ Populate matrix"
         id: set-matrix
@@ -56,7 +56,7 @@ jobs:
 
   test-changed-infrastructure:
     name: "🧪 ${{ matrix.coordinates }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
-    if: needs.get-changed-infrastructure.outputs.relevant-files-changed == 'true' && needs.get-changed-infrastructure.result == 'success' && needs.get-changed-infrastructure.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
+    if: needs.get-changed-infrastructure.outputs.relevant-files-changed == 'true' && needs.get-changed-infrastructure.result == 'success' && needs.get-changed-infrastructure.outputs.none-found != 'true' && github.repository == 'jormundur00/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     needs: get-changed-infrastructure
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: ${{ matrix.version }}
 
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1

--- a/.github/workflows/test-changed-infrastructure.yml
+++ b/.github/workflows/test-changed-infrastructure.yml
@@ -74,18 +74,12 @@ jobs:
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools
 
-      - name: "🔧 Setup java"
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
-        with:
-          distribution: 'graalvm'
-          java-version: ${{ matrix.version }}
-
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           distribution: "graalvm"
           java-version: ${{ matrix.version }}
-          set-java-home: "false"
+          set-java-home: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: "true"
 

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "🕸️ Populate matrix"
         id: set-matrix
@@ -55,7 +55,7 @@ jobs:
 
   test-changed-metadata:
     name: "🧪 ${{ matrix.coordinates }} [batch ${{ matrix.batch }}] [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
-    if: needs.get-changed-metadata.outputs.relevant-files-changed == 'true' && needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
+    if: needs.get-changed-metadata.outputs.relevant-files-changed == 'true' && needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true' && github.repository == 'jormundur00/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 480
     needs: get-changed-metadata
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: ${{ matrix.version }}
 
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -72,18 +72,12 @@ jobs:
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools
 
-      - name: "🔧 Setup java"
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
-        with:
-          distribution: 'graalvm'
-          java-version: ${{ matrix.version }}
-
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.version }}
-          set-java-home: 'false'
+          set-java-home: 'true'
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -236,7 +236,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "Run deps.dev graph and capture raw dependency graph"
         env:

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -19,7 +19,7 @@ jobs:
   get-all-libraries:
     name: "📋 Get list of all supported libraries with newer versions"
     # Opens PRs, with labels and assignees. Works only on the main repo.
-    if: github.repository == 'oracle/graalvm-reachability-metadata'
+    if: github.repository == 'jormundur00/graalvm-reachability-metadata'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     permissions:
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "📅 Set branch name"
         id: set-branch-name
@@ -138,7 +138,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: ${{ matrix.version }}
 
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
@@ -253,7 +253,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'graalvm'
-          java-version: '21'
+          java-version: '25'
 
       - name: "📥 Download matrix results"
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -134,18 +134,12 @@ jobs:
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools
 
-      - name: "🔧 Setup java"
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
-        with:
-          distribution: 'graalvm'
-          java-version: ${{ matrix.version }}
-
       - name: "🔧 Download GraalVM for metadata testing"
         uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.version }}
-          set-java-home: 'false'
+          set-java-home: 'true'
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
+++ b/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
+++ b/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
+++ b/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/javassist/javassist/3.12.0.GA/build.gradle
+++ b/tests/src/javassist/javassist/3.12.0.GA/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 tasks.withType(Test).configureEach {
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED", "-Djava.security.manager=allow"
 }

--- a/tests/src/org.apache.groovy/groovy-test-junit5/4.0.24/build.gradle
+++ b/tests/src/org.apache.groovy/groovy-test-junit5/4.0.24/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.jboss.resteasy/resteasy-core-spi/6.2.15.Final/build.gradle
+++ b/tests/src/org.jboss.resteasy/resteasy-core-spi/6.2.15.Final/build.gradle
@@ -28,7 +28,7 @@ graalvmNative {
 
 tasks.withType(Test).configureEach {
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     jvmArgs += ["-Djava.security.manager=allow"]
 }

--- a/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.parboiled:parboiled_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -13,6 +13,8 @@ import org.graalvm.buildtools.gradle.tasks.NativeRunTask
 import org.gradle.api.tasks.PathSensitivity
 
 import java.util.jar.JarFile
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 plugins {
     id 'org.graalvm.internal.tck-base'
@@ -29,8 +31,40 @@ repositories {
     mavenCentral()
 }
 
+Integer explicitTestJvmVersion(File buildFile) {
+    if (!buildFile.isFile()) {
+        return null
+    }
+
+    String buildScript = buildFile.getText("UTF-8")
+    List<Pattern> explicitVersionPatterns = [
+            ~/JavaLanguageVersion\.of\((\d+)\)/,
+            ~/jvmToolchain\((\d+)\)/,
+            ~/kotlinOptions\.jvmTarget\s*=\s*["'](\d+)["']/,
+            ~/options\.release\s*=\s*(\d+)/
+    ]
+
+    for (Pattern pattern : explicitVersionPatterns) {
+        Matcher matcher = pattern.matcher(buildScript)
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1))
+        }
+    }
+
+    null
+}
+
+int testJvmVersion = explicitTestJvmVersion(project.buildFile) ?: 25
+
 tasks.withType(JavaCompile).configureEach {
-    options.release = 25
+    options.release = testJvmVersion
+}
+
+plugins.withId("org.jetbrains.kotlin.jvm") {
+    project.kotlin.jvmToolchain(testJvmVersion)
+    tasks.named("compileTestKotlin").configure {
+        kotlinOptions.jvmTarget = testJvmVersion.toString()
+    }
 }
 
 tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach { task ->

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.release = 21
+    options.release = 25
 }
 
 tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach { task ->

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.groovy.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.groovy.template
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.kotlin.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.kotlin.template
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala2.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala2.template
@@ -15,13 +15,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "$group$:$artifact$:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala3.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala3.template
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
@@ -218,9 +218,9 @@ class ScaffoldTaskTests {
                 "/scaffold/build.gradle.kotlin.template"
         );
         assertThat(Files.readString(tempDir.resolve("tests/src/io.ktor/ktor-server-core-jvm/3.1.0/build.gradle"), StandardCharsets.UTF_8))
-                .contains("jvmToolchain(21)")
-                .contains("kotlinOptions.jvmTarget = \"21\"")
-                .doesNotContain("25");
+                .contains("jvmToolchain(25)")
+                .contains("kotlinOptions.jvmTarget = \"25\"")
+                .doesNotContain("21");
         List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
                 tempDir.resolve("metadata/io.ktor/ktor-server-core-jvm/index.json").toFile(),
                 new TypeReference<>() {}
@@ -268,8 +268,8 @@ class ScaffoldTaskTests {
         assertThat(Files.readString(tempDir.resolve("tests/src/org.apache.groovy/groovy-json/4.0.21/build.gradle"), StandardCharsets.UTF_8))
                 .contains("id \"groovy\"")
                 .contains("testImplementation localGroovy()")
-                .contains("JavaLanguageVersion.of(21)")
-                .doesNotContain("25");
+                .contains("JavaLanguageVersion.of(25)")
+                .doesNotContain("21");
         List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
                 tempDir.resolve("metadata/org.apache.groovy/groovy-json/index.json").toFile(),
                 new TypeReference<>() {}
@@ -315,8 +315,8 @@ class ScaffoldTaskTests {
                 "/scaffold/build.gradle.scala3.template"
         );
         assertThat(Files.readString(tempDir.resolve("tests/src/org.typelevel/cats-core_3/2.12.0/build.gradle"), StandardCharsets.UTF_8))
-                .contains("JavaLanguageVersion.of(21)")
-                .doesNotContain("25");
+                .contains("JavaLanguageVersion.of(25)")
+                .doesNotContain("21");
     }
 
     @Test
@@ -351,8 +351,8 @@ class ScaffoldTaskTests {
                 "/scaffold/build.gradle.scala2.template"
         );
         assertThat(Files.readString(tempDir.resolve("tests/src/org.typelevel/cats-core_2.13/2.12.0/build.gradle"), StandardCharsets.UTF_8))
-                .contains("JavaLanguageVersion.of(21)")
-                .doesNotContain("25");
+                .contains("JavaLanguageVersion.of(25)")
+                .doesNotContain("21");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- switch the shared TCK JavaCompile release and scaffolds from JDK 21 to JDK 25
- update a small Kotlin/Scala/Groovy/Java sample set to emit/run with JDK 25, including Scala 2.13.17 for the Scala 2 sample and scaffold
- make workflow setup-java use JDK 25 for non-matrix setup and the ci.json matrix JDK for test lanes that also install GraalVM
- enable the relevant test workflows on this fork by using jormundur00/graalvm-reachability-metadata guards

## Verification
- ./gradlew -p tests/tck-build-logic test --stacktrace
- ./gradlew compileTestJava -Pcoordinates=io.github.oshai:kotlin-logging-jvm:8.0.01 --stacktrace
- ./gradlew compileTestJava -Pcoordinates=org.parboiled:parboiled_2.13:2.5.1 --stacktrace
- ./gradlew compileTestJava -Pcoordinates=org.apache.groovy:groovy-test-junit5:4.0.24 --stacktrace
- ./gradlew compileTestJava -Pcoordinates=org.jboss.resteasy:resteasy-core-spi:6.2.15.Final --stacktrace
- ./gradlew generateChangedMetadataTestMatrix -PbaseCommit=jormundur00/master -PnewCommit=HEAD --stacktrace
- ./gradlew generateInfrastructureChangedCoordinatesMatrix -PbaseCommit=jormundur00/master -PnewCommit=HEAD --stacktrace
- git diff --check
